### PR TITLE
Pagination fix for front-page.php

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -2,19 +2,11 @@
 
 	<div id="main-content" class="row store-template">
 		<div class="content clearfix">
-			<?php
-			$current_page = get_query_var('page');
-			$per_page = get_option('posts_per_page');
-			$offset = $current_page > 0 ? $per_page * ($current_page-1) : 0;
-			$product_args = array(
-				'post_type' => 'download',
-				'posts_per_page' => $per_page,
-				'offset' => $offset
-			);
-			$products = new WP_Query($product_args);
-			?>
-			<?php if ($products->have_posts()) : $i = 1; ?>
-				<?php while ($products->have_posts()) : $products->the_post(); ?>
+			
+			<?php if ( have_posts() ) : $i = 1; ?>
+
+				<?php while ( have_posts() ) : the_post(); ?>
+
 					<div class="threecol product<?php if($i % 4 == 0) { echo ' last'; } ?>">
 						<a href="<?php the_permalink(); ?>">
 							<h2 class="title"><?php the_title(); ?></h2>
@@ -49,15 +41,18 @@
 				<?php endwhile; ?>
 				
 				<div class="pagination">
-					<?php 					
-						$big = 999999999; // need an unlikely intege					
-						echo paginate_links( array(
+
+					<?php 
+						$big = 999999999; // need an unlikely integer
+						echo paginate_links(array(
 							'base' => str_replace( $big, '%#%', esc_url( get_pagenum_link( $big ) ) ),
 							'format' => '?paged=%#%',
-							'current' => max( 1, $current_page ),
-							'total' => $products->max_num_pages
-						) );
+							'current' => max( 1, get_query_var('paged') ),
+							'total' => $wp_query->max_num_pages
+						));
+
 					?>
+
 				</div>
 			<?php else : ?>
 		

--- a/functions.php
+++ b/functions.php
@@ -77,3 +77,25 @@ if(!function_exists('edds_image_sizes')) {
 	}
 }
 add_action('init', 'edds_image_sizes');
+
+
+
+/**
+ * Alter the main loop on front_page.php
+ */
+
+function edd_modify_main_loop( $query ) {
+
+	$downloads_per_page = 4;
+
+	if ( is_admin() || ! $query->is_main_query() )
+		return;
+
+	if ( is_home() ) {
+		$query->set( 'posts_per_page', $downloads_per_page ); // make this number come from theme options
+		$query->set( 'post_type', 'download' ); // set post type to download
+		return;
+	}
+
+}
+add_action( 'pre_get_posts', 'edd_modify_main_loop', 1 );


### PR DESCRIPTION
https://github.com/pippinsplugins/EDD-Starter-Theme/issues/4
- Removed use of WP_Query and altered main loop using the pre_get_posts action hook.
- Used $query->set to define number of downloads to show and set post type.
